### PR TITLE
Channelの取得、登録のエンドポイントの作成

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -17,14 +17,14 @@ type BotEndpoint struct {
 }
 
 type Server struct {
-	Id   *uuid.UUID `json:"server_id" bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	Name string     `json:"name" bun:"name,notnull"`
+	Id   *uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name string     `bun:"name,notnull"`
 }
 
 type Channel struct {
-	Id       *uuid.UUID `json:"channel_id" bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	ServerId *uuid.UUID `json:"server_id" bun:"server_id,unique:serverIdAndChannelName,notnull,type:uuid"` //FK
-	Name     string     `json:"name" bun:"name,unique:serverIdAndChannelName,notnull"`
+	Id       *uuid.UUID `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	ServerId uuid.UUID  `bun:"server_id,unique:serverIdAndChannelName,notnull,type:uuid"` //FK
+	Name     string     `bun:"name,unique:serverIdAndChannelName,notnull"`
 }
 
 type User struct {
@@ -44,7 +44,7 @@ type User struct {
 // CHECK ((is_bot = true AND bot_endpoint_id IS NOT NULL) OR (is_bot = false AND user_id IS NOT NULL));`)
 type Message struct {
 	Id            *uuid.UUID `json:"message_id" bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	ChannelId     *uuid.UUID `json:"channel_id" bun:"channel_id,notnull,type:uuid"`   //FK
+	ChannelId     uuid.UUID  `json:"channel_id" bun:"channel_id,notnull,type:uuid"`   //FK
 	UserId        string     `json:"user_id" bun:"user_id"`                           //FK
 	BotEndpointId *uuid.UUID `json:"bot_endpoint_id" bun:"bot_endpoint_id,type:uuid"` //FK
 	CreatedAt     time.Time  `json:"created_at" bun:"created_at,nullzero,notnull,default:current_timestamp"`
@@ -58,8 +58,8 @@ type ServerBotEndpoint struct {
 }
 
 type UserServer struct {
-	UserId   string     `json:"user_id" bun:"user_id,pk"`               //FK
-	ServerId *uuid.UUID `json:"server_id" bun:"server_id,pk,type:uuid"` //FK
+	UserId   string    `json:"user_id" bun:"user_id,pk"`               //FK
+	ServerId uuid.UUID `json:"server_id" bun:"server_id,pk,type:uuid"` //FK
 }
 
 type UserReaction struct {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/hebitigo/CATechAccelChatApp/usecase"
@@ -93,6 +94,11 @@ type requestRegisterServer struct {
 	Name   string `json:"name" validate:"required"`
 }
 
+type responseRegisterServer struct {
+	ServerID string `json:"server_id"`
+	Name     string `json:"name"`
+}
+
 func (handler *ServerHandler) RegisterServer(c *gin.Context) {
 	var request requestRegisterServer
 	err := c.BindJSON(&request)
@@ -120,11 +126,21 @@ func (handler *ServerHandler) RegisterServer(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(200, gin.H{"message": "server registered successfully", "server_id": serverId})
+	response := responseRegisterServer{
+		ServerID: serverId,
+		Name:     request.Name,
+	}
+
+	c.JSON(200, response)
 }
 
 type requestGetServersByUserID struct {
-	UserId string `uri:"user_Id" validate:"required"`
+	UserId string `uri:"user_id" validate:"required"`
+}
+
+type responseGetServersByUserID struct {
+	ServerID string `json:"server_id"`
+	Name     string `json:"name"`
 }
 
 func (handler *ServerHandler) GetServersByUserID(c *gin.Context) {
@@ -156,7 +172,14 @@ func (handler *ServerHandler) GetServersByUserID(c *gin.Context) {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(200, servers)
+	var response []responseGetServersByUserID
+	for _, server := range servers {
+		response = append(response, responseGetServersByUserID{
+			ServerID: server.Id.String(),
+			Name:     server.Name,
+		})
+	}
+	c.JSON(200, response)
 }
 
 type UserHandler struct {
@@ -200,4 +223,104 @@ func (handler *UserHandler) UpsertUser(c *gin.Context) {
 		return
 	}
 	c.JSON(200, gin.H{"message": "user upserted successfully"})
+}
+
+type ChannelHandler struct {
+	usecase usecase.ChannelUsecaseInterface
+}
+
+func NewChannelHandler(usecase usecase.ChannelUsecaseInterface) *ChannelHandler {
+	return &ChannelHandler{usecase: usecase}
+}
+
+type requestRegisterChannel struct {
+	ServerId string `json:"server_id" validate:"required,uuid"`
+	Name     string `json:"name" validate:"required"`
+}
+
+type responseRegisterChannel struct {
+	ChannelID string `json:"channel_id"`
+	Name      string `json:"name"`
+}
+
+func (handler *ChannelHandler) RegisterChannel(c *gin.Context) {
+	var request requestRegisterChannel
+	err := c.BindJSON(&request)
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+	validator := validate.GetValidater()
+	err = validator.Struct(request)
+	if err != nil {
+		c.JSON(400, gin.H{"error": fmt.Sprintf("request validation failed:%s", err.Error())})
+		return
+	}
+	//uuidに変換する処理
+	serverId, err := uuid.Parse(request.ServerId)
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+
+	registerChannelInputDTO := usecase.RegisterChannelInputDTO{
+		ServerId:    serverId,
+		ChannelName: request.Name,
+	}
+	channelId, err := handler.usecase.RegisterChannel(c.Request.Context(), registerChannelInputDTO)
+	if err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	response := responseRegisterChannel{
+		ChannelID: channelId,
+		Name:      request.Name,
+	}
+	c.JSON(200, response)
+}
+
+type requestGetChannelsByServerID struct {
+	ServerId string `uri:"server_id" validate:"required,uuid"`
+}
+
+type responseGetChannelsByServerID struct {
+	ChannelID string `json:"channel_id"`
+	Name      string `json:"name"`
+}
+
+func (handler *ChannelHandler) GetChannelsByServerID(c *gin.Context) {
+	var request requestGetChannelsByServerID
+	err := c.BindUri(&request)
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+	log.Printf("request -> %+v", request)
+	validator := validate.GetValidater()
+	err = validator.Struct(request)
+	if err != nil {
+		c.JSON(400, gin.H{"error": fmt.Sprintf("request validation failed:%s", err.Error())})
+		return
+	}
+	serverId, err := uuid.Parse(request.ServerId)
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+	getChannelsByServerIDInputDTO := usecase.GetChannelsByServerIDInputDTO{
+		ServerId: serverId,
+	}
+	channels, err := handler.usecase.GetChannelsByServerID(c.Request.Context(), getChannelsByServerIDInputDTO)
+	if err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	var response []responseGetChannelsByServerID
+	for _, channel := range channels {
+		response = append(response, responseGetChannelsByServerID{
+			ChannelID: channel.Id.String(),
+			Name:      channel.Name,
+		})
+	}
+	c.JSON(200, response)
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -49,7 +49,7 @@ func (repo *BotEndpointRepository) Insert(botEndpoint entity.BotEndpoint) error 
 }
 
 type ServerRepositoryInterface interface {
-	Insert(ctx context.Context, e entity.Server) (serverId *uuid.UUID, err error)
+	Insert(ctx context.Context, e entity.Server) (serverId uuid.UUID, err error)
 	GetServersByUserID(ctx context.Context, userId string) ([]entity.Server, error)
 }
 
@@ -61,14 +61,14 @@ func NewServerRepository(db *bun.DB) *ServerRepository {
 	return &ServerRepository{db: db}
 }
 
-func (repo *ServerRepository) Insert(ctx context.Context, e entity.Server) (serverId *uuid.UUID, err error) {
+func (repo *ServerRepository) Insert(ctx context.Context, e entity.Server) (serverId uuid.UUID, err error) {
 	Insert := GetInsertQuery(ctx, repo.db)
 
 	_, err = Insert.Model(&e).Exec(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to insert server. server -> %+v:", e))
+		return uuid.Nil, errors.Wrap(err, fmt.Sprintf("failed to insert server. server -> %+v:", e))
 	}
-	return e.Id, nil
+	return *e.Id, nil
 }
 
 func (repo *ServerRepository) GetServersByUserID(ctx context.Context, userId string) ([]entity.Server, error) {
@@ -117,7 +117,8 @@ func (repo *UserServerRepository) Insert(ctx context.Context, e entity.UserServe
 }
 
 type ChannelRepositoryInterface interface {
-	Insert(ctx context.Context, e entity.Channel) error
+	Insert(ctx context.Context, e entity.Channel) (channelId uuid.UUID, err error)
+	GetChannelsByServerID(ctx context.Context, serverId uuid.UUID) ([]entity.Channel, error)
 }
 
 type ChannelRepository struct {
@@ -128,14 +129,23 @@ func NewChannelRepository(db *bun.DB) *ChannelRepository {
 	return &ChannelRepository{db: db}
 }
 
-func (repo *ChannelRepository) Insert(ctx context.Context, e entity.Channel) error {
+func (repo *ChannelRepository) Insert(ctx context.Context, e entity.Channel) (channelId uuid.UUID, err error) {
 	Insert := GetInsertQuery(ctx, repo.db)
 
-	_, err := Insert.Model(&e).Exec(ctx)
+	_, err = Insert.Model(&e).Exec(ctx)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to insert channel. channel -> %+v:", e))
+		return uuid.Nil, errors.Wrap(err, fmt.Sprintf("failed to insert channel. channel -> %+v:", e))
 	}
-	return nil
+	return *e.Id, nil
+}
+
+func (repo *ChannelRepository) GetChannelsByServerID(ctx context.Context, serverId uuid.UUID) ([]entity.Channel, error) {
+	var channels []entity.Channel
+	err := repo.db.NewSelect().Model(&channels).Where("server_id = ?", serverId).Scan(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to get channels by server_id. server_id -> %s", serverId))
+	}
+	return channels, nil
 }
 
 type TxRepositoryInterface interface {

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -64,7 +64,7 @@ type RegisterServerInputDTO struct {
 }
 
 func (usecase *ServerUsecase) RegisterServer(ctx context.Context, dto RegisterServerInputDTO) (string, error) {
-	var serverId *uuid.UUID
+	var serverId uuid.UUID
 	var err error
 	err = usecase.TxRepo.DoInTx(ctx, func(ctx context.Context) error {
 		server := entity.Server{Name: dto.ServerName}
@@ -78,8 +78,8 @@ func (usecase *ServerUsecase) RegisterServer(ctx context.Context, dto RegisterSe
 			return err
 		}
 
-		channel := entity.Channel{Name: "default", ServerId: serverId}
-		err = usecase.ChannelRepo.Insert(ctx, channel)
+		channel := entity.Channel{Name: "general", ServerId: serverId}
+		_, err = usecase.ChannelRepo.Insert(ctx, channel)
 		if err != nil {
 			return err
 		}
@@ -130,4 +130,47 @@ func (usecase *UserUsecase) UpsertUser(ctx context.Context, dto UpsertUserInputD
 		return err
 	}
 	return nil
+}
+
+type ChannelUsecaseInterface interface {
+	GetChannelsByServerID(ctx context.Context, dto GetChannelsByServerIDInputDTO) ([]entity.Channel, error)
+	RegisterChannel(ctx context.Context, dto RegisterChannelInputDTO) (string, error)
+}
+
+type ChannelUsecase struct {
+	channelRepo repository.ChannelRepositoryInterface
+}
+
+func NewChannelUsecase(channelRepo repository.ChannelRepositoryInterface) *ChannelUsecase {
+	return &ChannelUsecase{channelRepo: channelRepo}
+}
+
+// UserId以外のIdを元にデータを取得する際は、entityのIdの型を参考にしてInputDTOのIdの型を決める
+// serverIdはentityではServer構造体のIdの型は*uuid.UUIDだけど、これはデータベース側にuuidを自動生成させる
+// ためにポインタを使ってServer構造体のIdの値をnilにできるようにしているだけで、実際にIdをもとに検索を書ける場合は
+// Idの値がnilになることはないので、InputDTOのServerIdの型はuuid.UUIDになる
+type GetChannelsByServerIDInputDTO struct {
+	ServerId uuid.UUID
+}
+
+func (usecase *ChannelUsecase) GetChannelsByServerID(ctx context.Context, dto GetChannelsByServerIDInputDTO) ([]entity.Channel, error) {
+	channels, err := usecase.channelRepo.GetChannelsByServerID(ctx, dto.ServerId)
+	if err != nil {
+		return nil, err
+	}
+	return channels, nil
+}
+
+type RegisterChannelInputDTO struct {
+	ServerId    uuid.UUID
+	ChannelName string
+}
+
+func (usecase *ChannelUsecase) RegisterChannel(ctx context.Context, dto RegisterChannelInputDTO) (string, error) {
+	channel := entity.Channel{Name: dto.ChannelName, ServerId: dto.ServerId}
+	channelId, err := usecase.channelRepo.Insert(ctx, channel)
+	if err != nil {
+		return "", err
+	}
+	return channelId.String(), nil
 }

--- a/ws/user.go
+++ b/ws/user.go
@@ -75,7 +75,7 @@ func (u *User) readPump() {
 
 		message := entity.Message{
 			UserId:        u.UserID,
-			ChannelId:     &u.ChannelID,
+			ChannelId:     u.ChannelID,
 			IsBot:         false,
 			Message:       stringMessage,
 			BotEndpointId: nil,


### PR DESCRIPTION
GET /channels/:server_id
POST /channel
のエンドポイントを作りました。

あとentityのuuidのフィールドのうちいくつかを*uuid.UUIDからuuid.UUIDへ型を変更しました。
ポインタにしていたのはデータをInsertする際、テーブルのプライマリキーに対応する構造体のIdにデータが入ってない状態をnilで許容することでデータベース側にUUIDを生成してもらうためで、それ以外の場合はデータベースの操作は全てUUIDが入った状態で操作が行われないといけないためポインタではなくuuid.UUIDに型を変更しました。