### PR TITLE
feat: fix websocket connection and add GetMessages handler

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -73,3 +73,10 @@ type ReactionType struct {
 	Id    string `json:"reaction_type_id" bun:"id,pk,type:uuid,default:gen_random_uuid()"`
 	Emoji string `json:"emoji" bun:"emoji,notnull"`
 }
+
+// MessageWithUserはmessageテーブルとusersテーブルをJOINしてメッセージを取得する際に使用する
+type MessageWithUser struct {
+	Message
+	UserName string `bun:"user_name"`
+	IconURL  string `bun:"user_icon_image_url"`
+}

--- a/router/router.go
+++ b/router/router.go
@@ -52,8 +52,12 @@ func InitRouter(db *bun.DB, ctx context.Context) *gin.Engine {
 	hub := ws.NewHub()
 	go hub.Run()
 	messageRepository := repository.NewMessageRepository(db)
-	wsHandler := ws.NewHandler(hub, messageRepository)
-	r.GET("/ws/channel/join/:server_id/:channel_id/:user_id", wsHandler.JoinChannel)
+	wsHandler := ws.NewHandler(hub, messageRepository, userRepostiory)
+	r.GET("/ws/:user_id", wsHandler.JoinChannel)
+
+	messageUseCase := usecase.NewMessageUsecase(messageRepository)
+	messageHandler := handler.NewMessageHandler(messageUseCase)
+	r.GET("/messages/:channel_id", messageHandler.GetMessagesByChannelID)
 
 	return r
 }

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -289,3 +289,27 @@ func (usecase *ChannelUsecase) RegisterChannel(ctx context.Context, dto Register
 	}
 	return channelId.String(), nil
 }
+
+type MessageUsecaseInterface interface {
+	GetMessagesByChannelID(ctx context.Context, dto GetMessagesByChannelIDInputDTO) ([]entity.MessageWithUser, error)
+}
+
+type MessageUsecase struct {
+	messageRepo repository.MessageRepositoryInterface
+}
+
+func NewMessageUsecase(messageRepo repository.MessageRepositoryInterface) *MessageUsecase {
+	return &MessageUsecase{messageRepo: messageRepo}
+}
+
+type GetMessagesByChannelIDInputDTO struct {
+	ChannelId uuid.UUID
+}
+
+func (usecase *MessageUsecase) GetMessagesByChannelID(ctx context.Context, dto GetMessagesByChannelIDInputDTO) ([]entity.MessageWithUser, error) {
+	messages, err := usecase.messageRepo.GetMessagesWithUser(ctx, dto.ChannelId)
+	if err != nil {
+		return nil, err
+	}
+	return messages, nil
+}

--- a/util/validate.go
+++ b/util/validate.go
@@ -1,4 +1,4 @@
-package validate
+package util
 
 import "github.com/go-playground/validator/v10"
 

--- a/ws/hub.go
+++ b/ws/hub.go
@@ -1,80 +1,46 @@
 package ws
 
-import "github.com/google/uuid"
-
-type channelId uuid.UUID
-
-type serverId uuid.UUID
-
-type broadcastMessage struct {
-	serverId    serverId
-	channelId   channelId
-	jsonMessage []byte
-}
+type userId string
 
 type Hub struct {
-	UserPresence map[serverId]map[channelId]map[*User]bool
-	broadcast    chan broadcastMessage
+	UserPresence map[userId]*User
+	broadcast    chan []byte
 	register     chan *User
 	unregister   chan *User
 }
 
 func NewHub() *Hub {
 	return &Hub{
-		broadcast:    make(chan broadcastMessage),
+		broadcast:    make(chan []byte),
 		register:     make(chan *User),
 		unregister:   make(chan *User),
-		UserPresence: make(map[serverId]map[channelId]map[*User]bool),
+		UserPresence: make(map[userId]*User),
 	}
 }
 
+// userが参加しているサーバー、チャンネルはメッセージには含むがbackend側ではその情報を元に
+// broadcastするサーバー、チャンネルを絞る混む事はしない
+// backend側ではuserがオンラインかどうか、websocketで接続しているかどうかをHubで管理し、
+// なんらかの情報がフロントエンドのwebscoketから送られてきた場合には、
+// Hubに登録されている全てのuserに対してbroadcastする
 func (h *Hub) Run() {
 	for {
 		select {
 		case user := <-h.register:
-			//websocketで接続されたアクティブなユーザーをhubに格納するので、
-			//hub上にSeverやChannelが登録されているかどうかは
-			//DBに登録されているかどうかとはまた別の話で
-			//DBにサーバーが登録されていたとしても、websocketで接続要求がきたuserの参加しているサーバー、チャンネル以外は
-			//hubに登録されない
-			if _, ok := h.UserPresence[serverId(user.ServerID)]; !ok {
-				h.UserPresence[serverId(user.ServerID)] = make(map[channelId]map[*User]bool)
-			}
-			if _, ok := h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)]; !ok {
-				h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)] = make(map[*User]bool)
-			}
-
-			h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)][user] = true
+			h.UserPresence[userId(user.UserID)] = user
 		case user := <-h.unregister:
-			if _, ok := h.UserPresence[serverId(user.ServerID)]; ok {
-				if _, ok := h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)]; ok {
-					if _, ok := h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)][user]; ok {
-						delete(h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)], user)
-						close(user.send)
-						if len(h.UserPresence[serverId(user.ServerID)][channelId(user.ChannelID)]) == 0 {
-							delete(h.UserPresence[serverId(user.ServerID)], channelId(user.ChannelID))
-						}
-						if len(h.UserPresence[serverId(user.ServerID)]) == 0 {
-							delete(h.UserPresence, serverId(user.ServerID))
-						}
-					}
-				}
+			if _, ok := h.UserPresence[userId(user.UserID)]; ok {
+				delete(h.UserPresence, userId(user.UserID))
+				close(user.send)
 			}
 		case broadcastInfo := <-h.broadcast:
-			if _, ok := h.UserPresence[broadcastInfo.serverId]; ok {
-				if _, ok := h.UserPresence[broadcastInfo.serverId][broadcastInfo.channelId]; ok {
-					for user := range h.UserPresence[broadcastInfo.serverId][broadcastInfo.channelId] {
-						select {
-						case user.send <- broadcastInfo:
-						//user.sendが閉じてる場合のブロッキングを防ぐためにdefaultを設定
-						default:
-							close(user.send)
-							delete(h.UserPresence[broadcastInfo.serverId][broadcastInfo.channelId], user)
-							if len(h.UserPresence[broadcastInfo.serverId][broadcastInfo.channelId]) == 0 {
-								delete(h.UserPresence[broadcastInfo.serverId], broadcastInfo.channelId)
-							}
-						}
-					}
+			for _, user := range h.UserPresence {
+				select {
+				case user.send <- broadcastInfo:
+				//user.sendが閉じてる場合のブロッキングを防ぐためにdefaultを設定
+				default:
+					close(user.send)
+					delete(h.UserPresence, userId(user.UserID))
 				}
 			}
 

--- a/ws/user.go
+++ b/ws/user.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hebitigo/CATechAccelChatApp/entity"
 	"github.com/hebitigo/CATechAccelChatApp/repository"
+	"github.com/hebitigo/CATechAccelChatApp/util"
 )
 
 const (
@@ -23,21 +24,68 @@ const (
 )
 
 type User struct {
-	ChannelID   uuid.UUID
-	ServerID    uuid.UUID
 	UserID      string
 	hub         *Hub
 	conn        *websocket.Conn
-	send        chan broadcastMessage
+	send        chan []byte
 	messageRepo repository.MessageRepositoryInterface
+	userRepo    repository.UserRepositoryInterface
 	ctx         context.Context
 }
 
-type ReturnMessage struct {
-	Name         string    `json:"name"`
-	Message      string    `json:"message"`
-	CreatedAt    time.Time `json:"created_at"`
-	IconImageURL string    `json:"icon_image_url"`
+type actionType string
+
+const (
+	chatMessageAction  actionType = "chat_message"
+	addChannelAction   actionType = "add_channel"
+	userActivateAction actionType = "user_activate"
+	errorAction        actionType = "error"
+)
+
+type incomingChatMessageInfo struct {
+	ServerId  string `json:"server_id" validate:"required,uuid"`
+	ChannelId string `json:"channel_id" validate:"required,uuid"`
+	Message   string `json:"message" validate:"required"`
+}
+
+type outgoingChatMessageInfo struct {
+	UserName         string    `json:"user_name"`
+	UserIconImageURL string    `json:"user_icon_image_url"`
+	ServerId         string    `json:"server_id"`
+	ChannelId        string    `json:"channel_id"`
+	Message          string    `json:"message"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
+type channelInfo struct {
+	Name      string `json:"name"`
+	ServerId  string `json:"server_id"`
+	ChannelId string `json:"channel_id"`
+}
+
+type returnError struct {
+	Message string `json:"message"`
+}
+
+type readMessage struct {
+	ActionType actionType      `json:"action_type" validate:"required"`
+	Payload    json.RawMessage `json:"payload" validate:"required"`
+}
+
+type Payload interface {
+	outgoingChatMessageInfo | incomingChatMessageInfo | channelInfo | returnError
+}
+
+type SendMessage struct {
+	ActionType actionType  `json:"action_type"`
+	Payload    interface{} `json:"payload"`
+}
+
+func returnSendMessage[P Payload](at actionType, p P) SendMessage {
+	return SendMessage{
+		ActionType: at,
+		Payload:    p,
+	}
 }
 
 func (u *User) readPump() {
@@ -61,46 +109,107 @@ func (u *User) readPump() {
 		u.conn.SetReadDeadline(time.Now().Add(pongWait))
 		return nil
 	})
+	validator := util.GetValidater()
+Loop:
 	for {
 		_, byteMessage, err := u.conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
 				err = errors.Wrap(err, fmt.Sprintf("read message from websocket is failed.err is unexpected error. byteMessage -> %+v", byteMessage))
 				log.Printf("%+v", err)
 			}
 			break
 		}
 
-		stringMessage := string(byteMessage)
-
-		message := entity.Message{
-			UserId:        u.UserID,
-			ChannelId:     u.ChannelID,
-			IsBot:         false,
-			Message:       stringMessage,
-			BotEndpointId: nil,
-		}
-
-		createdAt, err := u.messageRepo.Insert(u.ctx, message)
+		var readMessage readMessage
+		err = json.Unmarshal(byteMessage, &readMessage)
 		if err != nil {
-			log.Printf("failed to insert message provided by websocket: %+v", err)
+			err = errors.Wrap(err, fmt.Sprintf("cant unmarshal byteMessage from Websocket. byteMessage -> %+v", byteMessage))
+			log.Printf("%+v", err)
+
+			sendWebsocketError(u.conn, err)
+			break
+		}
+		err = validator.Struct(readMessage)
+		if err != nil {
+			err = errors.Wrap(err, fmt.Sprintf("readMessage is invalid. readMessage -> %+v", readMessage))
+			log.Printf("%+v", err)
+			sendWebsocketError(u.conn, err)
 			break
 		}
 
-		returnMessage, err := json.Marshal(ReturnMessage{
-			Name:      u.UserID,
-			Message:   stringMessage,
-			CreatedAt: createdAt,
-		})
-		if err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("cant marshal Channel Message. returnMessage -> %+v", returnMessage))
-			log.Printf("%v", err)
-			break
-		}
-		u.hub.broadcast <- broadcastMessage{
-			serverId:    serverId(u.ServerID),
-			channelId:   channelId(u.ChannelID),
-			jsonMessage: returnMessage,
+		switch readMessage.ActionType {
+		case chatMessageAction:
+			var chatMessageInfo incomingChatMessageInfo
+			err := json.Unmarshal(readMessage.Payload, &chatMessageInfo)
+			if err != nil {
+				err = errors.Wrap(err, fmt.Sprintf("cant unmarshal chatMessageInfo from readMessage.Payload. readMessage.Payload -> %+v", readMessage.Payload))
+				log.Printf("%+v", err)
+				sendWebsocketError(u.conn, err)
+				break
+			}
+			err = validator.Struct(chatMessageInfo)
+			if err != nil {
+				err = errors.Wrap(err, fmt.Sprintf("chatMessageInfo is invalid. chatMessageInfo -> %+v", chatMessageInfo))
+				log.Printf("%+v", err)
+				sendWebsocketError(u.conn, err)
+				break
+			}
+			channelId, err := uuid.Parse(chatMessageInfo.ChannelId)
+			if err != nil {
+				err = errors.Wrap(err, fmt.Sprintf("cant parse channelId. channelId -> %s", chatMessageInfo.ChannelId))
+				log.Printf("%+v", err)
+				sendWebsocketError(u.conn, err)
+				break
+			}
+
+			user, err := u.userRepo.GetUser(u.ctx, u.UserID)
+			if err != nil {
+				log.Printf("failed to get user info: %+v", err)
+				sendWebsocketError(u.conn, err)
+				break Loop
+
+			}
+
+			message := entity.Message{
+				UserId:        user.Id,
+				ChannelId:     channelId,
+				IsBot:         false,
+				Message:       chatMessageInfo.Message,
+				BotEndpointId: nil,
+			}
+			createdAt, err := u.messageRepo.Insert(u.ctx, message)
+			if err != nil {
+				log.Printf("failed to insert message provided by websocket: %+v", err)
+				sendWebsocketError(u.conn, err)
+				break
+
+			}
+
+			returnChatMessageInfo := outgoingChatMessageInfo{
+				UserName:         user.Name,
+				UserIconImageURL: user.IconImageURL,
+				CreatedAt:        createdAt,
+				ServerId:         chatMessageInfo.ServerId,
+				ChannelId:        chatMessageInfo.ChannelId,
+				Message:          chatMessageInfo.Message,
+			}
+			bytes, err := json.Marshal(returnSendMessage[outgoingChatMessageInfo](
+				chatMessageAction,
+				returnChatMessageInfo,
+			))
+			if err != nil {
+				err = errors.Wrap(err, fmt.Sprintf("cant marshal returnChatMessageInfo. returnChatMessageInfo -> %+v", returnChatMessageInfo))
+				log.Printf("%+v", err)
+				sendWebsocketError(u.conn, err)
+				break
+			}
+			u.hub.broadcast <- bytes
+		default:
+			err = errors.New(fmt.Sprintf("unexpected actionType. actionType -> %s", readMessage.ActionType))
+			log.Printf("%+v", err)
+			sendWebsocketError(u.conn, err)
+			break Loop
 		}
 	}
 
@@ -114,7 +223,7 @@ func (u *User) writePump() {
 	}()
 	for {
 		select {
-		case broadcastMessage, ok := <-u.send:
+		case payload, ok := <-u.send:
 			u.conn.SetWriteDeadline(time.Now().Add(writeWait))
 			if !ok {
 				u.conn.WriteMessage(websocket.CloseMessage, []byte{})
@@ -124,27 +233,46 @@ func (u *User) writePump() {
 			if err != nil {
 				err = errors.Wrap(err, "failed to get next writer:")
 				log.Printf("%+v", err)
+				sendWebsocketError(u.conn, err)
 				return
 			}
-			w.Write(broadcastMessage.jsonMessage)
+			w.Write(payload)
 
 			n := len(u.send)
 			for i := 0; i < n; i++ {
-				broadcastMessage := <-u.send
-				w.Write(broadcastMessage.jsonMessage)
+				payload := <-u.send
+				w.Write(payload)
 			}
 			err = w.Close()
 			if err != nil {
 				err = errors.Wrap(err, "failed to close writer:")
 				log.Printf("%+v", err)
+				sendWebsocketError(u.conn, err)
 				return
 			}
 		case <-ticker.C:
 			u.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			log.Printf("ping and deadline is set")
 			err := u.conn.WriteMessage(websocket.PingMessage, nil)
 			if err != nil {
 				return
 			}
 		}
+	}
+}
+
+func sendWebsocketError(conn *websocket.Conn, err error) {
+	conn.SetWriteDeadline(time.Now().Add(writeWait))
+	bytes, err := json.Marshal(returnSendMessage[returnError](errorAction, returnError{Message: err.Error()}))
+	if err != nil {
+		err = errors.Wrap(err, fmt.Sprintf("cant marshal error message. err -> %+v", err))
+		log.Printf("%+v", err)
+		return
+	}
+	err = conn.WriteMessage(websocket.TextMessage, bytes)
+	if err != nil {
+		err = errors.Wrap(err, fmt.Sprintf("failed to write message to websocket. message -> %+v", bytes))
+		log.Printf("%+v", err)
+		return
 	}
 }


### PR DESCRIPTION
ws/ディレクトリを全体的に改修し、
ws/:user_id
で接続した後は基本的に切断しないように変更しました。
websocketから送られたメッセージを
```
type readMessage struct {
	ActionType actionType      `json:"action_type" validate:"required"`
	Payload    json.RawMessage `json:"payload" validate:"required"`
}
```
で受け取りActionTypeでどのメッセージのタイプを受け取ったかを判別し、switchでメッセージごとに処理を分けれるようにしました。

チャンネルIDに紐づけられたメッセージを一括で取得するエンドポイントである
GET /messages/:channel_id
も追加しました。